### PR TITLE
Check esim functionality in a device

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A comprehensive Flutter plugin that provides extensive access to SIM card and ne
 - **Phone Number**: Retrieve the phone number associated with the SIM
 - **SIM State**: Check current SIM card state (READY, ABSENT, PIN_REQUIRED, etc.)
 - **SIM Presence**: Detect if a SIM card is present in the device
+- **Is eSIM**: Check if the SIM card is eSIM or not.
 
 ### Network Information
 
@@ -34,6 +35,7 @@ A comprehensive Flutter plugin that provides extensive access to SIM card and ne
 ### Device Information
 
 - **Device ID**: Get device IMEI/MEID identifier
+- **Supports eSim**: Tells if the device supports eSIM (Requires entitlements in IOS)
 
 ## 🔧 Installation
 
@@ -73,7 +75,7 @@ Add the following permission to your `android/app/src/main/AndroidManifest.xml`:
 
 ### iOS
 
-No additional setup required for iOS 9.0 - 13.x.
+No additional setup required for iOS 9.0 - 13.x. However, entitlement is required for a method (SimCardManager.supportsEsim)
 
 ## 🚀 Usage
 
@@ -230,6 +232,55 @@ try {
 } catch (e) {
   print('Error getting device ID: $e');
 }
+
+// If the device supports eSIM or not (entitlement is required on IOS).
+try {
+  final supportsEsim = await SimCardManager.supportsEsim;
+  print('Supports ESIM: $supportsEsim');
+} catch (e) {
+  print('Error checking eSIM compatability: $e');
+}
+```
+
+### eSIM Integration Guidelines for iOS
+
+#### Compatibility Check:
+
+You can check if eSIM functionality is supported by a device in your iOS app by following the steps below. Please note that the process involves requesting entitlement approval from Apple.
+https://developer.apple.com//contact/request/esim-access-entitlement
+
+#### Steps:
+
+##### Step 1: Request eSIM Entitlement
+
+Using your developer account, submit a request for the eSIM entitlement through the Apple Developer portal.
+
+##### Step 2: Approval Process
+
+Apple will review and approve the entitlement request. You can check the status of the approval in your app's profile settings.
+
+##### Step 3: Download Profiles
+
+Download the App Development and Distribution profiles. Ensure that the eSIM entitlement is selected as part of Step #2 in the profile settings.
+
+##### Step 4: Update Info.plist
+
+Update your Info.plist file with the following keys and values:
+
+```xml
+<key>CarrierDescriptors</key>
+<array>
+  <dict>
+    <key>GID1</key>
+    <string>***</string>
+    <key>GID2</key>
+    <string>***</string>
+    <key>MCC</key> <!-- Country Code -->
+    <string>***</string>
+    <key>MNC</key> <!-- Network Code -->
+    <string>***</string>
+  </dict>
+</array>
 ```
 
 ## 📊 SIM States

--- a/android/src/main/kotlin/com/example/sim_card_code/SimCardCodePlugin.kt
+++ b/android/src/main/kotlin/com/example/sim_card_code/SimCardCodePlugin.kt
@@ -44,6 +44,7 @@ class SimCardCodePlugin: FlutterPlugin, MethodCallHandler {
       "isDualSim" -> isDualSim(result)
       "isEsim" -> isEsim(result)
       "getDeviceId" -> getDeviceId(result)
+      "supportsEsim" -> checkSupportForEsim(result)
       else -> result.notImplemented()
     }
   }
@@ -449,6 +450,26 @@ class SimCardCodePlugin: FlutterPlugin, MethodCallHandler {
       result.success(if (deviceId.isNullOrEmpty()) null else deviceId)
     } catch (e: Exception) {
       result.error("DEVICE_ID_ERROR", e.message, null)
+    }
+  }
+
+  /**
+   * Method which checks if the device has support for eSIM based on the the hardware component.
+   *
+   */
+  private fun checkSupportForEsim(result:Result){
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P){
+      val pm = context.packageManager
+      try{
+        val hasEuiccFeature = pm.hasSystemFeature(PackageManager.FEATURE_TELEPHONY_EUICC)
+
+        result.success(hasEuiccFeature)
+      }catch (e: Exception){
+        result.error("ESIM_CHECK_ERROR",e.message,null)
+      }
+    }
+    else{
+      result.success(false)
     }
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,6 +42,7 @@ class _SimCardDashboardState extends State<SimCardDashboard>
   bool _hasSimCard = false;
   bool _isDualSim = false;
   int _simCount = 0;
+  bool _supportsEsim = false;
 
   // UI State
   bool _isLoading = true;
@@ -89,6 +90,7 @@ class _SimCardDashboardState extends State<SimCardDashboard>
         SimCardManager.hasSimCard,
         SimCardManager.isDualSim,
         SimCardManager.simCount,
+        SimCardManager.supportsEsim,
       ]);
 
       if (mounted) {
@@ -100,6 +102,7 @@ class _SimCardDashboardState extends State<SimCardDashboard>
           _hasSimCard = results[4] as bool;
           _isDualSim = results[5] as bool;
           _simCount = results[6] as int;
+          _supportsEsim = results[7] as bool;
           _isLoading = false;
         });
       }
@@ -505,6 +508,7 @@ class _SimCardDashboardState extends State<SimCardDashboard>
                   _buildInfoRow('SIM Slots', _simCount.toString()),
                   _buildInfoRow('Dual SIM Support', _isDualSim ? 'Yes' : 'No'),
                   _buildInfoRow('SIM Card Present', _hasSimCard ? 'Yes' : 'No'),
+                  _buildInfoRow('eSIM Support', _supportsEsim ? 'Yes' : 'No'),
                 ],
               ),
             ),

--- a/ios/Classes/SimCardCodePlugin.swift
+++ b/ios/Classes/SimCardCodePlugin.swift
@@ -43,6 +43,8 @@ public class SimCardCodePlugin: NSObject, FlutterPlugin {
       getDeviceId(result: result)
     case "isEsim":
         isEsim(result: result)
+    case "supportsEsim":
+        checkSupportForEsim(result:result)
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -468,4 +470,28 @@ private func isEsim(result: @escaping FlutterResult) {
     // Otherwise, assume no eSIM
     result(false)
 }
+    
+    /// Checks if the device supports eSIM and returns the result via FlutterResult.
+    /// - iOS 16+: uses `supportsEmbeddedSIM` (hardware check)
+    /// - iOS 12–15: uses `supportsCellularPlan()` (installation policy)
+    ///   - Note: installation (activation) policy depends on several factors, including:
+    ///     - Carrier restrictions
+    ///     - Device management profiles (MDM) controlled by an administrator
+    ///     - Region or country-specific limitations
+    ///
+    /// - Also requires entitlement `com.apple.developer.esim-access`
+    ///
+    private func checkSupportForEsim(result: @escaping FlutterResult){
+            let provisioning = CTCellularPlanProvisioning()
+            if #available(iOS 16.0, *){
+                result(provisioning.supportsEmbeddedSIM)
+            }
+           else if #available(iOS 12.0, *){
+                result(provisioning.supportsCellularPlan())
+            }else{
+                result(false)
+            }
+        
+       
+    }
 }

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -178,6 +178,7 @@ class SimCardManager {
   static bool? _isEsim;
   static String? _deviceId;
   static List<SimCardInfo>? _allSimInfo;
+  static bool? _supportsEsim;
 
   static Future<String?> get simCountryCode async =>
       _simCountryCode ??= await _invoke<String>('getSimCountryCode');
@@ -221,8 +222,16 @@ class SimCardManager {
   static Future<bool> get isDualSim async =>
       _isDualSim ??= await _invoke<bool>('isDualSim') ?? false;
 
+  /// Method to tell whether the default SIM is and ESIM or not
+  ///
   static Future<bool> get isEsim async =>
       _isEsim ??= await _invoke<bool>('isEsim') ?? false;
+
+  /// Method to check if the device supports eSIM functionality
+  /// based on hardware capabilities.
+  ///
+  static Future<bool> get supportsEsim async =>
+      _supportsEsim ??= await _invoke<bool>('supportsEsim') ?? false;
 
   static Future<String?> get deviceId async =>
       _deviceId ??= await _invoke<String>('getDeviceId');

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -230,6 +230,12 @@ class SimCardManager {
   /// Method to check if the device supports eSIM functionality
   /// based on hardware capabilities.
   ///
+  /// Note: On iOS less than 16.0 , actual eSIM usage may also depend on region restrictions,
+  /// carrier policies, and device management profiles.
+  ///
+  /// ⚠️ On iOS, calling `supportsEsim` requires the `com.apple.developer.esim-access` entitlement.
+  /// Without this entitlement, the check will **always return `false`**, even on devices that support eSIM.
+  ///
   static Future<bool> get supportsEsim async =>
       _supportsEsim ??= await _invoke<bool>('supportsEsim') ?? false;
 


### PR DESCRIPTION
# PR: Add eSIM Hardware Support Detection for Android and iOS

## ✨ Summary

This PR introduces a new feature to detect **whether a device supports eSIM at the hardware level**, independent of whether an eSIM is currently active or provisioned.

- Added method: `supportsEsim`
- Implemented for **both Android and iOS**
- Properly documented in `README.md`

---
## 🍎 iOS Implementation Notes

- The `supportsEsim` method uses the `CTCellularPlanProvisioning` API to check eSIM hardware support.
- **Entitlement Required:**  
  To use this API, your app must have the Apple entitlement:  
  `com.apple.developer.esim-access`
- Without this entitlement, the method will **always return false**, even on devices that support eSIM.
